### PR TITLE
Only use text from Text Nodes

### DIFF
--- a/lib/rules/body.js
+++ b/lib/rules/body.js
@@ -64,7 +64,7 @@ module.exports = exports = function(payload, fn) {
     var lines = content.split('\n');
 
     // get the text lines
-    var spellingTexts = []
+    var spellingTexts = [];
 
     // create a list of tags to use
     for(var i = 0; i < elementTags.length; i++) {
@@ -73,11 +73,18 @@ module.exports = exports = function(payload, fn) {
       $('body ' + elementTags[i]).each(function(index, elem) {
 
         // push the item
-        spellingTexts.push(spellCheck.trim( $(elem).text() ));
+        spellingTexts.push(spellCheck.trim( $(elem).contents().filter(function() {
+            
+          // return only the text
+          return this.type === 'text';
+
+        }).text() ));
 
       });
 
     }
+
+    console.dir(spellingTexts)
 
     // get the content
     spellCheck.check({

--- a/lib/spellcheck.js
+++ b/lib/spellcheck.js
@@ -442,6 +442,10 @@ SpellCheck.check = function(params, fn) {
     if(S(cleanedWord).trim().isEmpty() === true)
       continue;
 
+    // right check if not blank
+    if(S(cleanedWord).trim().endsWith('..') === true)
+      continue;
+
     // must not contain a number
     if((cleanedWord || '').match(/\d+/gi) != null)
       continue;


### PR DESCRIPTION
Updated to only use the text nodes instead of the simple - `.text()` - in a attempt to better handle and remove any HTML we might be getting false-positives from